### PR TITLE
Support Facebook paging

### DIFF
--- a/openfb.js
+++ b/openfb.js
@@ -157,11 +157,13 @@ var openFB = (function() {
         var method = obj.method || 'GET',
             params = obj.params || {},
             xhr = new XMLHttpRequest(),
-            url;
+            url = 'https://graph.facebook.com';
 
         params['access_token'] = tokenStore['fbtoken'];
 
         url = 'https://graph.facebook.com' + obj.path + '?' + toQueryString(params);
+        
+        if (obj.path.indexOf(url) >= 0 ) url = obj.path + '?' + toQueryString(params);
 
         xhr.onreadystatechange = function() {
             if (xhr.readyState === 4) {


### PR DESCRIPTION
Support Facebook paging since most Facebook API endpoints return paging.next JSON node and those nodes already have https://graph.facebook.com in the url. If the obj.path already contains https://graph.facebook.com it suppose not be added again.
