### PR TITLE
The `init` method now accepts an optional Facebook `accessToken`.

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
     openFB.init('YOUR_FB_APP_ID'); // Defaults to sessionStorage for storing the Facebook token
 
 //  Uncomment the line below to store the Facebook token in localStorage instead of sessionStorage
-//  openFB.init('YOUR_FB_APP_ID', 'http://localhost/openfb/oauthcallback.html', window.localStorage);
+//  openFB.init('YOUR_FB_APP_ID', {store: window.localStorage});
 
     function login() {
         openFB.login('email',

--- a/openfb.js
+++ b/openfb.js
@@ -36,13 +36,18 @@ var openFB = (function () {
      * Initialize the OpenFB module. You must use this function and initialize the module with an appId before you can
      * use any other function.
      * @param appId - The id of the Facebook app
-     * @param redirectURL - The OAuth redirect URL. Optional. If not provided, we use sensible defaults.
-     * @param store - The store used to save the Facebook token. Optional. If not provided, we use sessionStorage.
+     * @param options - Options object. Can include:
+     *  redirectURL: The OAuth redirect URL. Optional. If not provided, we use sensible defaults.
+     *  store: The store used to save the Facebook token. Optional. If not provided, we use sessionStorage.
+     *  accessToken: The Facebook token. Optional.
      */
-    function init(appId, redirectURL, store) {
+    function init(appId, options) {
         fbAppId = appId;
-        if (redirectURL) oauthRedirectURL = redirectURL;
-        if (store) tokenStore = store;
+
+        options = options || {};
+        if (options.redirectURL) oauthRedirectURL = options.redirectURL;
+        if (options.store) tokenStore = options.store;
+        if (options.accessToken) tokenStore['fbtoken'] = options.accessToken;
     }
 
     /**


### PR DESCRIPTION
Breaking change: `init` takes an optional `options` arguments, which replaces the optional `redirectURL` & `store` arguments. See [`init` method](https://github.com/mrienstra/OpenFB/commit/35985ea2e31071270d8ed80c11680d74f1296ddc#diff-1) for details.

There are several scenarios in which your app might already have a valid `accessToken`. One example: if you use the [Cordova Facebook Plugin](https://github.com/phonegap/phonegap-facebook-plugin) for SSO (single sign-on).