### PR TITLE
fixed how the token is set when you want to explicitly set it

### DIFF
--- a/openfb.js
+++ b/openfb.js
@@ -57,7 +57,7 @@ var openFB = (function () {
         }
 
         if (params.tokenStore) {
-            tokenStore = params.tokenStore;
+            tokenStore['fbtoken'] = params.tokenStore;
         }
     }
 


### PR DESCRIPTION
When you explicitly set the auth token of a user when using openFB.init(), it wasn't being set to where the rest of the openFB script looks for it, so I updated that. Very small change