### PR TITLE
Update openfb.js

### DIFF
--- a/openfb.js
+++ b/openfb.js
@@ -141,7 +141,7 @@ var openFB = (function () {
             console.log('exit and remove listeners');
             // Handle the situation where the user closes the login window manually before completing the login process
             if (loginCallback && !loginProcessed) loginCallback({status: 'user_cancelled'});
-            loginWindow.removeEventListener('loadstop', loginWindow_loadStopHandler);
+            loginWindow.removeEventListener('loadstop', loginWindow_loadStartHandler);
             loginWindow.removeEventListener('exit', loginWindow_exitHandler);
             loginWindow = null;
             console.log('done removing listeners');


### PR DESCRIPTION
rocessMessage failed: Stack: ReferenceError: loginWindow_loadStopHandler is not defined
            at [object Object].loginWindow_exitHandler (file:///android_asset/www/js/openfb.js:145:57)
