### PR TITLE
Fix logout issue -  fbtoken should be fbAccessToken

### DIFF
--- a/openfb.js
+++ b/openfb.js
@@ -204,7 +204,7 @@ var openFB = (function () {
             token = tokenStore.fbAccessToken;
 
         /* Remove token. Will fail silently if does not exist */
-        tokenStore.removeItem('fbtoken');
+        tokenStore.removeItem('fbAccessToken');
 
         if (token) {
             logoutWindow = window.open(logoutURL + '?access_token=' + token + '&next=' + logoutRedirectURL, '_blank', 'location=no,clearcache=yes');


### PR DESCRIPTION
Fixes logout issue where token was not being deleted. Please see issue:
https://github.com/ccoenraets/OpenFB/issues/52
