### PR TITLE
make it compatible with cordova browser platform

### DIFF
--- a/oauthcallback.html
+++ b/oauthcallback.html
@@ -1,8 +1,10 @@
 <html>
 <body>
 <script>
+try{ //in case we call outside cordova browser platform
     window.opener.openFB.oauthCallback(window.location.href);
     window.close();
+    }catch(e){ console.log(e.description); }
 </script>
 </body>
 </html>

--- a/openfb.js
+++ b/openfb.js
@@ -37,7 +37,10 @@ var openFB = (function () {
         loginCallback,
 
     // Indicates if the app is running inside Cordova
-        runningInCordova,
+        runningInCordova = false,
+
+    // Indicates if the app is runniong on browser platform     
+        runningCordovaBrowser = false,
 
     // Used in the exit event handler to identify if the login has already been processed elsewhere (in the oauthCallback function)
         loginProcessed;
@@ -46,7 +49,11 @@ var openFB = (function () {
     // You don't need to (and should not) add the actual cordova.js file to your file system: it will be added automatically
     // by the Cordova build process
     document.addEventListener("deviceready", function () {
-        runningInCordova = true;
+        if(window.cordova.platformId=="browser"){
+			      runningCordovaBrowser=true; 
+		          cordovaOAuthRedirectURL =  oauthRedirectURL;
+			  }
+           runningInCordova = true;
     }, false);
 
     /**
@@ -83,7 +90,7 @@ var openFB = (function () {
         oauthRedirectURL = params.oauthRedirectURL || oauthRedirectURL;
         cordovaOAuthRedirectURL = params.cordovaOAuthRedirectURL || cordovaOAuthRedirectURL;
         logoutRedirectURL = params.logoutRedirectURL || logoutRedirectURL;
-
+        runningInCordova = params.runningInCordova || runningInCordova;
     }
 
     /**
@@ -122,9 +129,13 @@ var openFB = (function () {
             return callback({status: 'unknown', error: 'Facebook App Id not set.'});
         }
 
-        // Inappbrowser load start handler: Used when running in Cordova only
-        function loginWindow_loadStartHandler(event) {
+        // Inappbrowser load stop handler: Used when running in Cordova only
+        // inAppBrowser browser platform not fires loadstart event
+        function loginWindow_loadStopHandler(event) {
             var url = event.url;
+            //url may is Location object so check and convert to string
+            if (url !== null && typeof url === 'object') url = url.toString();
+            
             if (url.indexOf("access_token=") > 0 || url.indexOf("error=") > 0) {
                 // When we get the access token fast, the login window (inappbrowser) is still opening with animation
                 // in the Cordova app, and trying to close it while it's animating generates an exception. Wait a little...
@@ -155,12 +166,18 @@ var openFB = (function () {
         loginProcessed = false;
 
         startTime = new Date().getTime();
+        
+        if (runningCordovaBrowser==true)
         loginWindow = window.open(loginURL + '?client_id=' + fbAppId + '&redirect_uri=' + redirectURL +
-            '&response_type=token&scope=' + scope, '_blank', 'location=no,clearcache=yes');
+            '&response_type=token&scope=' + scope, '_system', 'location=no,clearcache=yes');
+          else  
+        loginWindow = window.open(loginURL + '?client_id=' + fbAppId + '&redirect_uri=' + redirectURL +
+             '&response_type=token&scope=' + scope, '_blank', 'location=no,clearcache=yes');
+
 
         // If the app is running in Cordova, listen to URL changes in the InAppBrowser until we get a URL with an access_token or an error
         if (runningInCordova) {
-            loginWindow.addEventListener('loadstart', loginWindow_loadStartHandler);
+            loginWindow.addEventListener('loadstop', loginWindow_loadStopHandler);
             loginWindow.addEventListener('exit', loginWindow_exitHandler);
         }
         // Note: if the app is running in the browser the loginWindow dialog will call back by invoking the
@@ -204,8 +221,7 @@ var openFB = (function () {
             token = tokenStore.fbAccessToken;
 
         /* Remove token. Will fail silently if does not exist */
-        tokenStore.removeItem('fbtoken');
-
+        tokenStore.removeItem('fbAccessToken');
         if (token) {
             logoutWindow = window.open(logoutURL + '?access_token=' + token + '&next=' + logoutRedirectURL, '_blank', 'location=no,clearcache=yes');
             if (runningInCordova) {


### PR DESCRIPTION
There many issues on cordova browser platform with inappbrowser wich is implemented via iframe, and loadstart and loaderror events are not being fired.
So whe change to loadstop as suggested from @jamesfdickinson  and if running on browser platform we open window on _system for login.
